### PR TITLE
Fix: typo on prop on TechInner's Flex component

### DIFF
--- a/components/feature/Tech.tsx
+++ b/components/feature/Tech.tsx
@@ -39,7 +39,7 @@ export const TechInner = ({ children }: ChildrenProps): ReactElement => (
     direction="row"
     whiteSpace="nowrap"
     sx={{ ...hideScrollbar, gap: ".5rem" }}
-    overFlowX={["auto", "visible"]}
+    overflowX={["auto", "visible"]}
     flexWrap={["nowrap", "wrap"]}
     py={1}
   >


### PR DESCRIPTION
Issue #83 has been created to update Chakra UI to a patched version where this allegedly can't happen again.