### PR TITLE
fix: incorrect simplebar CSS import path

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
 import { AppProps } from "next/app";
 import { ChakraProvider } from "@chakra-ui/react";
-import "simplebar/dist/simplebar.min.css";
+import "simplebar-react/dist/simplebar.min.css";
 import { ReactElement } from "react";
 import { Analytics } from "@vercel/analytics/react";
 import { theme } from "styles/theme";


### PR DESCRIPTION
This was picked up by attempting to run `next dev --turbo`!